### PR TITLE
Fix breaking in IE11 by swapping Array.prototype.find(not supported) with  Array.prototype.some(supported).

### DIFF
--- a/src/InfiniteLoader.js
+++ b/src/InfiniteLoader.js
@@ -124,7 +124,7 @@ export default class InfiniteLoader extends PureComponent<Props> {
     // This shouldn't be strictly necsesary, but is maybe nice to do.
     if (
       this._memoizedUnloadedRanges.length !== unloadedRanges.length ||
-      this._memoizedUnloadedRanges.find(
+      this._memoizedUnloadedRanges.some(
         ([startIndex, stopIndex], index) =>
           unloadedRanges[index][0] !== startIndex ||
           unloadedRanges[index][1] !== stopIndex


### PR DESCRIPTION
Array.find is not supported in IE11. Swapping it with Array.some.
Link to issue https://github.com/bvaughn/react-window-infinite-loader/issues/27