### PR TITLE
Show warning when itemCount prop is not assigned a number

### DIFF
--- a/src/InfiniteLoader.js
+++ b/src/InfiniteLoader.js
@@ -112,6 +112,12 @@ export default class InfiniteLoader extends PureComponent<Props> {
       threshold = 15,
     } = this.props;
 
+    if (typeof itemCount !== 'number') {
+      console.warn(
+        'InfiniteLoader "itemCount prop expects a number. Omitting this value prevents loadMoreItems from being called"'
+      );
+    }
+
     const unloadedRanges = scanForUnloadedRanges({
       isItemLoaded,
       itemCount,


### PR DESCRIPTION
**What does this MR do?**
This MR implements showing a warning in the console when the user omits or assigns a non-number value to itemCount prop