### PR TITLE
Memory Usage improvements

### DIFF
--- a/src/InfiniteLoader.js
+++ b/src/InfiniteLoader.js
@@ -121,13 +121,11 @@ export default class InfiniteLoader extends PureComponent<Props> {
     });
 
     // Avoid calling load-rows unless range has changed.
-    // This shouldn't be strictly necsesary, but is maybe nice to do.
+    // This shouldn't be strictly necessary, but is maybe nice to do.
     if (
       this._memoizedUnloadedRanges.length !== unloadedRanges.length ||
       this._memoizedUnloadedRanges.some(
-        ([startIndex, stopIndex], index) =>
-          unloadedRanges[index][0] !== startIndex ||
-          unloadedRanges[index][1] !== stopIndex
+        (startOrStop, index) => unloadedRanges[index] !== startOrStop
       )
     ) {
       this._memoizedUnloadedRanges = unloadedRanges;
@@ -139,8 +137,10 @@ export default class InfiniteLoader extends PureComponent<Props> {
     // loadMoreRows was renamed to loadMoreItems in v1.0.3; will be removed in v2.0
     const loadMoreItems = this.props.loadMoreItems || this.props.loadMoreRows;
 
-    unloadedRanges.forEach(([startIndex, stopIndex]) => {
-      let promise = loadMoreItems(startIndex, stopIndex);
+    for (let i = 0; i < unloadedRanges.length; i += 2) {
+      const startIndex = unloadedRanges[i];
+      const stopIndex = unloadedRanges[i + 1];
+      const promise = loadMoreItems(startIndex, stopIndex);
       if (promise != null) {
         promise.then(() => {
           // Refresh the visible rows if any of them have just been loaded.
@@ -174,6 +174,6 @@ export default class InfiniteLoader extends PureComponent<Props> {
           }
         });
       }
-    });
+    }
   }
 }

--- a/src/__tests__/scanForUnloadedRanges.js
+++ b/src/__tests__/scanForUnloadedRanges.js
@@ -22,7 +22,7 @@ describe('scanForUnloadedRanges', () => {
         startIndex: 0,
         stopIndex: 2,
       })
-    ).toEqual([[1, 1]]);
+    ).toEqual([1, 1]);
   });
 
   it('return a range of multiple unloaded rows', () => {
@@ -32,7 +32,7 @@ describe('scanForUnloadedRanges', () => {
         startIndex: 0,
         stopIndex: 2,
       })
-    ).toEqual([[0, 1]]);
+    ).toEqual([0, 1]);
   });
 
   it('return multiple ranges of unloaded rows', () => {
@@ -50,6 +50,6 @@ describe('scanForUnloadedRanges', () => {
         startIndex: 0,
         stopIndex: 6,
       })
-    ).toEqual([[1, 2], [4, 4], [6, 6]]);
+    ).toEqual([1, 2, 4, 4, 6, 6]);
   });
 });

--- a/src/scanForUnloadedRanges.js
+++ b/src/scanForUnloadedRanges.js
@@ -29,10 +29,10 @@ export default function scanForUnloadedRanges({
         rangeStartIndex = index;
       }
     } else if (rangeStopIndex !== null) {
-      unloadedRanges.push([
+      unloadedRanges.push(
         ((rangeStartIndex: any): number),
-        ((rangeStopIndex: any): number),
-      ]);
+        ((rangeStopIndex: any): number)
+      );
 
       rangeStartIndex = rangeStopIndex = null;
     }
@@ -54,25 +54,23 @@ export default function scanForUnloadedRanges({
       }
     }
 
-    unloadedRanges.push([
+    unloadedRanges.push(
       ((rangeStartIndex: any): number),
-      ((rangeStopIndex: any): number),
-    ]);
+      ((rangeStopIndex: any): number)
+    );
   }
 
   // Check to see if our first range ended prematurely.
   // In this case we should scan backwards to try filling our :minimumBatchSize.
   if (unloadedRanges.length) {
-    let firstRange = unloadedRanges[0];
-
     while (
-      firstRange[1] - firstRange[0] + 1 < minimumBatchSize &&
-      firstRange[0] > 0
+      unloadedRanges[1] - unloadedRanges[0] + 1 < minimumBatchSize &&
+      unloadedRanges[0] > 0
     ) {
-      let index = firstRange[0] - 1;
+      let index = unloadedRanges[0] - 1;
 
       if (!isItemLoaded(index)) {
-        firstRange[0] = index;
+        unloadedRanges[0] = index;
       } else {
         break;
       }

--- a/src/types.js
+++ b/src/types.js
@@ -1,3 +1,4 @@
 // @flow
 
-export type Ranges = Array<[number, number]>;
+// Ranges is array of pairs: [start0, stop0, start1, stop1, ..., startN, stopN]
+export type Ranges = Array<number>;


### PR DESCRIPTION
**Previously**

We allocated new array for each pair in ranges.

**Currently**

We allocate only one array of numbers. Where each even element is a start of the range and odd element is end of the range.

It should prevent unnecessary allocations and garbage collections. Also it should be more performant,