### PR TITLE
Support React v19 peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
     "**/*.js": "eslint --max-warnings 0"
   },
   "peerDependencies": {
-    "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0",
-    "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0"
+    "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",


### PR DESCRIPTION
Similar to what was done in #53.

I'd note that in that last PR, the yarn.lock was not updated, so I didn't do that here either. I figure @bvaughn can do that update separately if desired (I may not have the same yarn setup etc.)